### PR TITLE
Remove brainonfire.net

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -9365,7 +9365,6 @@ brainframes.com
 brainfras.cf
 brainglue.com
 brainhacksonline.com
-brainonfire.net
 brainpowernootropics.xyz
 brainsworld.com
 braintsunami.com


### PR DESCRIPTION
At Open Collective, we're using burner-email-providers and this was impacting one of our users.

Fix https://github.com/findie/burner-email-providers/issues/1

Is this the canonical repository? On GitHub, it seems it is https://github.com/wesbos/burner-email-providers But looking from NPM https://www.npmjs.com/package/burner-email-providers, it is this one https://github.com/findie/burner-email-providers

