### PR TITLE
fix for server code in client bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
     "types": "index.d.ts",
     "scripts": {
         "test": "node test.js"
-    }
+    },
+    "sideEffects": false
 }


### PR DESCRIPTION
Added `"sideEffects": false` to package.json to fix a bug where this package was bundled on the client where it shouldn't have been (crashing the app :-(

See this reference in the docs explaining the issue: https://remix.run/docs/en/v1/pages/gotchas#server-code-in-client-bundles

thanks!